### PR TITLE
Remove redundant release contributors field

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,9 +39,5 @@ template: |
 
   $CHANGES
 
-  ## Contributors
-
-  $CONTRIBUTORS
-
   ## Install from the command line
     docker pull ghcr.io/$OWNER/$REPOSITORY:v$RESOLVED_VERSION


### PR DESCRIPTION
<!--
  Creating a pull request template for your repository
  https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository 
-->

Remove redundant release contributors field
Contributors field is already added by release-drafter by default

Checklist:
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My build is green.
* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
